### PR TITLE
Patch for missing blocks in "Relationships" attribute

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "streamline-trp"
-version = "0.1.0"
+version = "0.1.2"
 description = ""
 authors = ["Doug Qian <douglas@spirals.so>"]
 readme = "README.md"

--- a/src-python/trp/trp2.py
+++ b/src-python/trp/trp2.py
@@ -138,7 +138,8 @@ class TBoundingBox():
         points.append(TPoint(x=self.left, y=self.top))
         points.append(TPoint(x=self.left + self.width, y=self.top))
         points.append(TPoint(x=self.left, y=self.top + self.height))
-        points.append(TPoint(x=self.left + self.width, y=self.top + self.height))
+        points.append(TPoint(x=self.left + self.width,
+                      y=self.top + self.height))
         return points
 
     @property
@@ -161,7 +162,7 @@ class TBoundingBox():
         Convert the bounding box definition to a list of floats, i.e only standard 
         Python types. The bounding box definition is [width, height, left, top].
         '''
-        #TODO: cannot we use some overloading on the dump method of marshmallow?
+        # TODO: cannot we use some overloading on the dump method of marshmallow?
         bbox_list: List[float] = [self.width, self.height, self.left, self.top]
         return bbox_list
 
@@ -179,7 +180,7 @@ class TBoundingBox():
         ---------
         bbox:
             A TBoundingBox object
-        
+
         Returns
         -------
         union_bbox
@@ -203,7 +204,8 @@ class TBoundingBox():
         a bounding box sides are always parallel to x and y axis
         """
         points = []
-        points.append(TPoint(x=self.left, y=self.top).rotate(origin_x=origin.x, origin_y=origin.y, degrees=degrees))
+        points.append(TPoint(x=self.left, y=self.top).rotate(
+            origin_x=origin.x, origin_y=origin.y, degrees=degrees))
         points.append(
             TPoint(x=self.left + self.width, y=self.top).rotate(origin_x=origin.x, origin_y=origin.y, degrees=degrees))
         points.append(
@@ -230,7 +232,8 @@ class TBoundingBox():
 
 class TBoundingBoxSchema(BaseSchema):
     width = m.fields.Float(data_key="Width", required=False, allow_none=False)
-    height = m.fields.Float(data_key="Height", required=False, allow_none=False)
+    height = m.fields.Float(
+        data_key="Height", required=False, allow_none=False)
     left = m.fields.Float(data_key="Left", required=False, allow_none=False)
     top = m.fields.Float(data_key="Top", required=False, allow_none=False)
 
@@ -255,7 +258,8 @@ class TGeometry():
 
     def ratio(self, doc_width=None, doc_height=None):
         self.bounding_box.ratio(doc_width=doc_width, doc_height=doc_height)
-        [x.ratio(doc_width=doc_width, doc_height=doc_height) for x in self.polygon]
+        [x.ratio(doc_width=doc_width, doc_height=doc_height)
+         for x in self.polygon]
 
     def rotate(self, origin: TPoint = TPoint(0, 0), degrees: float = 180.0):
         self.bounding_box.rotate(origin=origin, degrees=degrees)
@@ -263,12 +267,15 @@ class TGeometry():
 
     def scale(self, doc_width=None, doc_height=None):
         self.bounding_box.scale(doc_width=doc_width, doc_height=doc_height)
-        [x.scale(doc_width=doc_width, doc_height=doc_height) for x in self.polygon]
+        [x.scale(doc_width=doc_width, doc_height=doc_height)
+         for x in self.polygon]
 
 
 class TGeometrySchema(BaseSchema):
-    bounding_box = m.fields.Nested(TBoundingBoxSchema, data_key="BoundingBox", required=False, allow_none=False)
-    polygon = m.fields.List(m.fields.Nested(TPointSchema), data_key="Polygon", required=False, allow_none=False)
+    bounding_box = m.fields.Nested(
+        TBoundingBoxSchema, data_key="BoundingBox", required=False, allow_none=False)
+    polygon = m.fields.List(m.fields.Nested(
+        TPointSchema), data_key="Polygon", required=False, allow_none=False)
 
     @post_load
     def make_tgeometry(self, data, **kwargs):
@@ -292,13 +299,14 @@ class TQuerySchema(BaseSchema):
 
 @dataclass(eq=True, init=True, repr=True)
 class TRelationship():
-    type: str = field(default=None)    #type: ignore
-    ids: List[str] = field(default=None)    #type: ignore
+    type: str = field(default=None)  # type: ignore
+    ids: List[str] = field(default=None)  # type: ignore
 
 
 class TRelationshipSchema(BaseSchema):
     type = m.fields.String(data_key="Type", required=False, allow_none=False)
-    ids = m.fields.List(m.fields.String, data_key="Ids", required=False, allow_none=False)
+    ids = m.fields.List(m.fields.String, data_key="Ids",
+                        required=False, allow_none=False)
 
     @post_load
     def make_trelationship(self, data, **kwargs):
@@ -311,22 +319,22 @@ class TBlock():
     https://docs.aws.amazon.com/textract/latest/dg/API_Block.html
     as per this documentation none of the values is actually required
     """
-    geometry: TGeometry = field(default=None)    #type: ignore
-    id: str = field(default=None)    #type: ignore
-    block_type: str = field(default="")    #type: ignore
-    relationships: List[TRelationship] = field(default=None)    #type: ignore
-    confidence: float = field(default=None)    #type: ignore
-    text: str = field(default=None)    #type: ignore
-    column_index: int = field(default=None)    #type: ignore
-    column_span: int = field(default=None)    #type: ignore
-    entity_types: List[str] = field(default=None)    #type: ignore
-    page: int = field(default=None)    #type: ignore
-    row_index: int = field(default=None)    #type: ignore
-    row_span: int = field(default=None)    #type: ignore
-    selection_status: str = field(default=None)    #type: ignore
-    text_type: str = field(default=None)    #type: ignore
-    custom: dict = field(default=None)    #type: ignore
-    query: TQuery = field(default=None)    #type: ignore
+    geometry: TGeometry = field(default=None)  # type: ignore
+    id: str = field(default=None)  # type: ignore
+    block_type: str = field(default="")  # type: ignore
+    relationships: List[TRelationship] = field(default=None)  # type: ignore
+    confidence: float = field(default=None)  # type: ignore
+    text: str = field(default=None)  # type: ignore
+    column_index: int = field(default=None)  # type: ignore
+    column_span: int = field(default=None)  # type: ignore
+    entity_types: List[str] = field(default=None)  # type: ignore
+    page: int = field(default=None)  # type: ignore
+    row_index: int = field(default=None)  # type: ignore
+    row_span: int = field(default=None)  # type: ignore
+    selection_status: str = field(default=None)  # type: ignore
+    text_type: str = field(default=None)  # type: ignore
+    custom: dict = field(default=None)  # type: ignore
+    query: TQuery = field(default=None)  # type: ignore
 
     def __eq__(self, o: object) -> bool:
         if isinstance(o, TBlock):
@@ -346,18 +354,21 @@ class TBlock():
 
     def add_ids_to_relationships(self, ids: List[str], relationships_type: str = "CHILD"):
         """Only adds id if not already existing"""
-        relationship = self.get_relationships_for_type(relationship_type=relationships_type)
+        relationship = self.get_relationships_for_type(
+            relationship_type=relationships_type)
         if relationship:
             if not relationship.ids:
                 relationship.ids = list()
                 relationship.ids.extend(ids)
             else:
-                relationship.ids.extend(x for x in ids if x not in relationship.ids)
+                relationship.ids.extend(
+                    x for x in ids if x not in relationship.ids)
         else:
             # empty, set base
             if not self.relationships:
                 self.relationships = list()
-            self.relationships.append(TRelationship(type=relationships_type, ids=ids))
+            self.relationships.append(TRelationship(
+                type=relationships_type, ids=ids))
 
     def rotate(self, origin=TPoint(0.5, 0.5), degrees: float = 180):
         self.geometry.rotate(origin=origin, degrees=degrees)
@@ -365,19 +376,29 @@ class TBlock():
 
 class TBlockSchema(BaseSchema):
     block_type = m.fields.String(data_key="BlockType", allow_none=False)
-    geometry = m.fields.Nested(TGeometrySchema, data_key="Geometry", allow_none=False)
+    geometry = m.fields.Nested(
+        TGeometrySchema, data_key="Geometry", allow_none=False)
     id = m.fields.String(data_key="Id", allow_none=False)
-    relationships = m.fields.List(m.fields.Nested(TRelationshipSchema), data_key="Relationships", allow_none=False)
-    confidence = m.fields.Float(data_key="Confidence", required=False, allow_none=False)
+    relationships = m.fields.List(m.fields.Nested(
+        TRelationshipSchema), data_key="Relationships", allow_none=False)
+    confidence = m.fields.Float(
+        data_key="Confidence", required=False, allow_none=False)
     text = m.fields.String(data_key="Text", required=False, allow_none=False)
-    column_index = m.fields.Int(data_key="ColumnIndex", required=False, allow_none=False)
-    column_span = m.fields.Int(data_key="ColumnSpan", required=False, allow_none=False)
-    entity_types = m.fields.List(m.fields.String, data_key="EntityTypes", required=False, allow_none=False)
+    column_index = m.fields.Int(
+        data_key="ColumnIndex", required=False, allow_none=False)
+    column_span = m.fields.Int(
+        data_key="ColumnSpan", required=False, allow_none=False)
+    entity_types = m.fields.List(
+        m.fields.String, data_key="EntityTypes", required=False, allow_none=False)
     page = m.fields.Int(data_key="Page", required=False, allow_none=False)
-    row_index = m.fields.Int(data_key="RowIndex", required=False, allow_none=False)
-    row_span = m.fields.Int(data_key="RowSpan", required=False, allow_none=False)
-    selection_status = m.fields.String(data_key="SelectionStatus", required=False, allow_none=False)
-    text_type = m.fields.String(data_key="TextType", required=False, allow_none=False)
+    row_index = m.fields.Int(
+        data_key="RowIndex", required=False, allow_none=False)
+    row_span = m.fields.Int(
+        data_key="RowSpan", required=False, allow_none=False)
+    selection_status = m.fields.String(
+        data_key="SelectionStatus", required=False, allow_none=False)
+    text_type = m.fields.String(
+        data_key="TextType", required=False, allow_none=False)
     custom = m.fields.Dict(data_key="Custom", required=False, allow_none=False)
     query = m.fields.Nested(TQuerySchema, data_key="Query")
 
@@ -388,7 +409,7 @@ class TBlockSchema(BaseSchema):
 
 @dataclass(eq=True, init=True, repr=True)
 class TDocumentMetadata():
-    pages: int = field(default=None)    #type: ignore
+    pages: int = field(default=None)  # type: ignore
 
 
 class TDocumentMetadataSchema(BaseSchema):
@@ -401,13 +422,15 @@ class TDocumentMetadataSchema(BaseSchema):
 
 @dataclass(eq=True, init=True, repr=True)
 class TWarnings():
-    error_code: str = field(default=None)    #type: ignore
-    pages: List[int] = field(default=None)    #type: ignore
+    error_code: str = field(default=None)  # type: ignore
+    pages: List[int] = field(default=None)  # type: ignore
 
 
 class TWarningsSchema(BaseSchema):
-    pages = m.fields.List(m.fields.Int, data_key="Pages", required=False, allow_none=False)
-    error_code = m.fields.String(data_key="ErrorCode", required=False, allow_none=False)
+    pages = m.fields.List(m.fields.Int, data_key="Pages",
+                          required=False, allow_none=False)
+    error_code = m.fields.String(
+        data_key="ErrorCode", required=False, allow_none=False)
 
     @post_load
     def make_twarnings(self, data, **kwargs):
@@ -416,37 +439,38 @@ class TWarningsSchema(BaseSchema):
 
 @dataclass(eq=True, init=True, repr=True)
 class THttpHeaders():
-    x_amzn_request_id: str = field(default=None)    #type: ignore
-    content_type: str = field(default=None)    #type: ignore
-    content_length: int = field(default=None)    #type: ignore
-    connection: str = field(default=None)    #type: ignore
-    date: str = field(default=None)    #type: ignore
+    x_amzn_request_id: str = field(default=None)  # type: ignore
+    content_type: str = field(default=None)  # type: ignore
+    content_length: int = field(default=None)  # type: ignore
+    connection: str = field(default=None)  # type: ignore
+    date: str = field(default=None)  # type: ignore
 
 
 @dataclass(eq=True, init=True, repr=True)
 class TResponseMetadata():
-    request_id: str = field(default=None)    #type: ignore
-    http_status_code: int = field(default=None)    #type: ignore
-    retry_attempts: int = field(default=None)    #type: ignore
-    http_headers: THttpHeaders = field(default=None)    #type: ignore
+    request_id: str = field(default=None)  # type: ignore
+    http_status_code: int = field(default=None)  # type: ignore
+    retry_attempts: int = field(default=None)  # type: ignore
+    http_headers: THttpHeaders = field(default=None)  # type: ignore
 
 
 @dataclass(eq=True, init=True, repr=True)
 class TDocument():
-    document_metadata: TDocumentMetadata = field(default=None)    #type: ignore
+    document_metadata: TDocumentMetadata = field(default=None)  # type: ignore
     # if blocks are changed, call __post_init__() to update the index
-    blocks: List[TBlock] = field(default=None)    #type: ignore
-    analyze_document_model_version: str = field(default=None)    #type: ignore
-    detect_document_text_model_version: str = field(default=None)    #type: ignore
-    status_message: str = field(default=None)    #type: ignore
-    warnings: TWarnings = field(default=None)    #type: ignore
-    job_status: str = field(default=None)    #type: ignore
-    response_metadata: TResponseMetadata = field(default=None)    #type: ignore
-    custom: dict = field(default=None)    #type: ignore
-    next_token: str = field(default=None)    #type: ignore
+    blocks: List[TBlock] = field(default=None)  # type: ignore
+    analyze_document_model_version: str = field(default=None)  # type: ignore
+    detect_document_text_model_version: str = field(
+        default=None)  # type: ignore
+    status_message: str = field(default=None)  # type: ignore
+    warnings: TWarnings = field(default=None)  # type: ignore
+    job_status: str = field(default=None)  # type: ignore
+    response_metadata: TResponseMetadata = field(default=None)  # type: ignore
+    custom: dict = field(default=None)  # type: ignore
+    next_token: str = field(default=None)  # type: ignore
     id: UUID = field(default_factory=uuid4)
 
-    def __post_init__(self):    #this is a dataclass method
+    def __post_init__(self):  # this is a dataclass method
         '''
         Build several hashmaps (signature: Dict[str, int]) with 
         the block ID as key and the block index in self.blocks as value. As Textract 
@@ -495,7 +519,7 @@ class TDocument():
         else:
             return {k: self.blocks[v] for k, v in self._block_id_maps['ALL'].items()}
 
-    def add_block(self, block: TBlock, page: TBlock = None):    #type: ignore
+    def add_block(self, block: TBlock, page: TBlock = None):  # type: ignore
         '''
         Add a block to the document at a give page. If the page is None, the block is 
         added to the first page
@@ -509,10 +533,12 @@ class TDocument():
             self._block_id_maps['ALL'][block.id] = len(self.blocks) - 1
             if block.block_type != '':
                 try:
-                    self._block_id_maps[block.block_type][block.id] = len(self.blocks) - 1
+                    self._block_id_maps[block.block_type][block.id] = len(
+                        self.blocks) - 1
                 except KeyError:
                     self._block_id_maps[block.block_type] = dict()
-                    self._block_id_maps[block.block_type][block.id] = len(self.blocks) - 1
+                    self._block_id_maps[block.block_type][block.id] = len(
+                        self.blocks) - 1
         if not page:
             page = self.pages[0]
         page.add_ids_to_relationships(ids=[block.id])
@@ -527,16 +553,21 @@ class TDocument():
         xmin = min([p.x for p in all_points])
         ymax = max([p.y for p in all_points])
         xmax = max([p.x for p in all_points])
-        new_bb = TBoundingBox(width=ymax - ymin, height=xmax - xmin, top=ymin, left=xmin)
-        new_poly = [TPoint(x=xmin, y=ymin), TPoint(x=xmax, y=ymin), TPoint(x=xmax, y=ymax), TPoint(x=xmin, y=ymax)]
+        new_bb = TBoundingBox(
+            width=ymax - ymin, height=xmax - xmin, top=ymin, left=xmin)
+        new_poly = [TPoint(x=xmin, y=ymin), TPoint(x=xmax, y=ymin), TPoint(
+            x=xmax, y=ymax), TPoint(x=xmin, y=ymax)]
         return TGeometry(bounding_box=new_bb, polygon=new_poly)
 
     @staticmethod
     def create_value_block(values: List[TBlock]) -> TBlock:
-        value_block = TBlock(id=str(uuid4()), block_type="KEY_VALUE_SET", entity_types=["VALUE"])
+        value_block = TBlock(
+            id=str(uuid4()), block_type="KEY_VALUE_SET", entity_types=["VALUE"])
         value_block.add_ids_to_relationships([b.id for b in values])
-        value_block.geometry = TDocument.create_geometry_from_blocks(values=values)
-        value_block.confidence = statistics.mean([b.confidence for b in values])
+        value_block.geometry = TDocument.create_geometry_from_blocks(
+            values=values)
+        value_block.confidence = statistics.mean(
+            [b.confidence for b in values])
         return value_block
 
     def add_virtual_block(self, text: str, page_block: TBlock, text_type="VIRTUAL") -> TBlock:
@@ -563,11 +594,13 @@ class TDocument():
         if not key_name:
             raise ValueError("need values and key_name")
         if not values:
-            logger.debug(f"add_key_values: empty values for key: {key_name}, will create virtual empty block")
+            logger.debug(
+                f"add_key_values: empty values for key: {key_name}, will create virtual empty block")
             values = [self.add_virtual_block(text="", page_block=page_block)]
         for value_block in values:
             if not value_block.id or not self.get_block_by_id(value_block.id):
-                raise ValueError("value blocks to add have to already exist. Use add_word_block for new ones.")
+                raise ValueError(
+                    "value blocks to add have to already exist. Use add_word_block for new ones.")
 
         if values[0].page:
             page_block = self.pages[values[0].page - 1]
@@ -577,7 +610,8 @@ class TDocument():
         value_block = TDocument.create_value_block(values=values)
         self.add_block(value_block, page=page_block)
 
-        virtual_block = self.add_virtual_block(text=key_name, page_block=page_block)
+        virtual_block = self.add_virtual_block(
+            text=key_name, page_block=page_block)
         id = str(uuid4())
         key_block = TBlock(id=id,
                            block_type="KEY_VALUE_SET",
@@ -586,8 +620,10 @@ class TDocument():
                            geometry=TGeometry(bounding_box=TBoundingBox(width=0, height=0, left=0, top=0),
                                               polygon=[TPoint(x=0, y=0), TPoint(x=0, y=0)]),
                            page=page_block.page)
-        key_block.add_ids_to_relationships(relationships_type="VALUE", ids=[value_block.id])
-        key_block.add_ids_to_relationships(relationships_type="CHILD", ids=[virtual_block.id])
+        key_block.add_ids_to_relationships(
+            relationships_type="VALUE", ids=[value_block.id])
+        key_block.add_ids_to_relationships(
+            relationships_type="CHILD", ids=[virtual_block.id])
         logger.debug(f"add key with id: {id} and key_name: {key_name}")
         self.add_block(key_block, page=page_block)
         return key_block
@@ -599,7 +635,8 @@ class TDocument():
             raise ValueError("need a page to rotate")
         if not degrees:
             raise ValueError("need degrees to rotate")
-        [b.rotate(origin=origin, degrees=float(degrees)) for b in self.relationships_recursive(block=page)]
+        [b.rotate(origin=origin, degrees=float(degrees))
+         for b in self.relationships_recursive(block=page)]
         self.relationships_recursive.cache_clear()
 
     def find_block_by_id(self, id: str) -> Optional[TBlock]:
@@ -616,11 +653,22 @@ class TDocument():
         else:
             raise ValueError(f"no block for id: {id}")
 
+    # Sometimes Textract returns a block with an id in "Relationships" that is not present in the flattened list of blocks.
+    # This is a Textract bug upstream of TRP workaround for that.
+    # See "dd615b1f-dad5-487d-8702-8db7c16e8a9a" in "test-jamie-python.pdf" for org "spirals"
+    def try_get_block_by_id(self, id: str) -> TBlock:
+        try:
+            return self.get_block_by_id(id)
+        except:
+            return None
+
     def __relationships_recursive(self, block: TBlock) -> Iterator[TBlock]:
         import itertools
         if block and block.relationships:
-            all_relations = list(itertools.chain(*[r.ids for r in block.relationships if r and r.ids]))
-            all_block = [self.get_block_by_id(id) for id in all_relations if id]
+            all_relations = list(itertools.chain(
+                *[r.ids for r in block.relationships if r and r.ids]))
+            all_block = [self.try_get_block_by_id(
+                id) for id in all_relations if id]
             for b in all_block:
                 if b:
                     yield b
@@ -639,7 +687,7 @@ class TDocument():
 
     @staticmethod
     def filter_blocks_by_type(block_list: List[TBlock],
-                              textract_block_type: list[TextractBlockTypes] = None) -> List[TBlock]:    #type: ignore
+                              textract_block_type: list[TextractBlockTypes] = None) -> List[TBlock]:  # type: ignore
         if textract_block_type:
             block_type_names = [x.name for x in textract_block_type]
             return [b for b in block_list if b.block_type in block_type_names]
@@ -656,8 +704,8 @@ class TDocument():
 
     def get_blocks_by_type(
             self,
-            block_type_enum: TextractBlockTypes = None,    #type: ignore
-            page: TBlock = None) -> List[TBlock]:    #type: ignore
+            block_type_enum: TextractBlockTypes = None,  # type: ignore
+            page: TBlock = None) -> List[TBlock]:  # type: ignore
         table_list: List[TBlock] = list()
         if page and page.relationships:
             block_list = list(self.relationships_recursive(page))
@@ -676,10 +724,10 @@ class TDocument():
             else:
                 return list()
 
-    def forms(self, page: TBlock = None) -> List[TBlock]:    #type: ignore
+    def forms(self, page: TBlock = None) -> List[TBlock]:  # type: ignore
         return self.get_blocks_by_type(page=page, block_type_enum=TextractBlockTypes.KEY_VALUE_SET)
 
-    def keys(self, page: TBlock = None) -> List[TBlock]:    #type: ignore
+    def keys(self, page: TBlock = None) -> List[TBlock]:  # type: ignore
         return [x for x in self.forms(page=page) if TextractEntityTypes.KEY.name in x.entity_types]
 
     def signatures(self, page: TBlock) -> List[TBlock]:
@@ -702,7 +750,8 @@ class TDocument():
             answers = [x for x in self.get_answers_for_query(block=query)]
             if answers:
                 for answer in answers:
-                    result_list.append([query.query.text, query.query.alias, answer.text])
+                    result_list.append(
+                        [query.query.text, query.query.alias, answer.text])
             else:
                 result_list.append([query.query.text, query.query.alias, ""])
         return result_list
@@ -718,7 +767,8 @@ class TDocument():
                     result_blocks.append(key)
         return result_blocks
 
-    def get_blocks_for_relationships(self, relationship: TRelationship = None) -> List[TBlock]:    #type: ignore
+    # type: ignore
+    def get_blocks_for_relationships(self, relationship: TRelationship = None) -> List[TBlock]:
         all_blocks: List[TBlock] = list()
         if relationship and relationship.ids:
             for id in relationship.ids:
@@ -730,17 +780,18 @@ class TDocument():
         if TextractEntityTypes.KEY.name in key.entity_types:
             if key and key.relationships:
                 value_blocks = self.get_blocks_for_relationships(
-                    relationship=key.get_relationships_for_type("VALUE"))    #type: ignore
+                    relationship=key.get_relationships_for_type("VALUE"))  # type: ignore
                 for block in value_blocks:
                     return_value_for_key.extend(self.get_blocks_for_relationships(
-                        block.get_relationships_for_type()))    #type: ignore
+                        block.get_relationships_for_type()))  # type: ignore
 
         return return_value_for_key
 
     @staticmethod
     def get_text_for_tblocks(tblocks: List[TBlock]) -> str:
         return_value = ' '.join([x.text for x in tblocks if x and x.text])
-        return_value += ' '.join([x.selection_status for x in tblocks if x and x.selection_status])
+        return_value += ' '.join(
+            [x.selection_status for x in tblocks if x and x.selection_status])
         return return_value
 
     def lines(self, page: TBlock) -> List[TBlock]:
@@ -758,15 +809,16 @@ class TDocument():
     # combine any tables with overlapping ids
     def combine_tables(self, table_array_ids: List[List[str]]):
         head, *tail = table_array_ids
-        if(len(tail) == 0):
+        if (len(tail) == 0):
             return [head]
-        if(head[-1] == tail[0][0]):
+        if (head[-1] == tail[0][0]):
             return self.combine_tables([head + tail[0][1:]] + tail[1:])
         else:
             return [head] + self.combine_tables(tail)
 
     def merge_tables(self, table_array_ids: List[List[str]]):
-        table_array_ids = [] if len(table_array_ids) == 0 else self.combine_tables(table_array_ids)
+        table_array_ids = [] if len(
+            table_array_ids) == 0 else self.combine_tables(table_array_ids)
         for table_ids in table_array_ids:
             if len(table_ids) < 2:
                 raise ValueError("no parent and child tables given")
@@ -782,7 +834,8 @@ class TDocument():
             for table_id in table_ids:
                 if parent_relationships and parent_relationships.ids:
                     parent_last_row = None
-                    parent_last_row_block = self.get_block_by_id(parent_relationships.ids[-1])
+                    parent_last_row_block = self.get_block_by_id(
+                        parent_relationships.ids[-1])
                     if parent_last_row_block:
                         parent_last_row = parent_last_row_block.row_index
                     child_table = self.get_block_by_id(table_id)
@@ -800,7 +853,8 @@ class TDocument():
                                                 entity_type for entity_type in cell_block.entity_types if entity_type != TextractEntityTypes.COLUMN_HEADER.name]
 
                                         if parent_relationships.ids and cell_id not in parent_relationships.ids:
-                                            parent_relationships.ids.append(cell_id)
+                                            parent_relationships.ids.append(
+                                                cell_id)
                     self.delete_blocks([table_id])
 
     def link_tables(self, table_array_ids: List[List[str]]):
@@ -828,10 +882,14 @@ class THttpHeadersSchema(BaseSchema):
         unknown = m.EXCLUDE
 
     date = m.fields.String(data_key="date", required=False)
-    x_amzn_request_id = m.fields.String(data_key="x-amzn-requestid", required=False, allow_none=False)
-    content_type = m.fields.String(data_key="content-type", required=False, allow_none=False)
-    content_length = m.fields.Int(data_key="content-length", required=False, allow_none=False)
-    connection = m.fields.String(data_key="connection", required=False, allow_none=False)
+    x_amzn_request_id = m.fields.String(
+        data_key="x-amzn-requestid", required=False, allow_none=False)
+    content_type = m.fields.String(
+        data_key="content-type", required=False, allow_none=False)
+    content_length = m.fields.Int(
+        data_key="content-length", required=False, allow_none=False)
+    connection = m.fields.String(
+        data_key="connection", required=False, allow_none=False)
 
     @post_load
     def make_thttp_headers(self, data, **kwargs):
@@ -843,10 +901,14 @@ class TResponseMetadataSchema(BaseSchema):
     class Meta:
         unknown = m.EXCLUDE
 
-    request_id = m.fields.String(data_key="RequestId", required=False, allow_none=False)
-    http_status_code = m.fields.Int(data_key="HTTPStatusCode", required=False, allow_none=False)
-    retry_attempts = m.fields.Int(data_key="RetryAttempts", required=False, allow_none=False)
-    http_headers = m.fields.Nested(THttpHeadersSchema, data_key="HTTPHeaders", required=False, allow_none=False)
+    request_id = m.fields.String(
+        data_key="RequestId", required=False, allow_none=False)
+    http_status_code = m.fields.Int(
+        data_key="HTTPStatusCode", required=False, allow_none=False)
+    retry_attempts = m.fields.Int(
+        data_key="RetryAttempts", required=False, allow_none=False)
+    http_headers = m.fields.Nested(
+        THttpHeadersSchema, data_key="HTTPHeaders", required=False, allow_none=False)
 
     @post_load
     def make_tresponse_metadata(self, data, **kwargs):
@@ -858,17 +920,22 @@ class TDocumentSchema(BaseSchema):
                                         data_key="DocumentMetadata",
                                         required=False,
                                         allow_none=False)
-    blocks = m.fields.List(m.fields.Nested(TBlockSchema), data_key="Blocks", required=False, allow_none=False)
+    blocks = m.fields.List(m.fields.Nested(TBlockSchema),
+                           data_key="Blocks", required=False, allow_none=False)
     analyze_document_model_version = m.fields.String(data_key="AnalyzeDocumentModelVersion",
                                                      required=False,
                                                      allow_none=False)
     detect_document_text_model_version = m.fields.String(data_key="DetectDocumentTextModelVersion",
                                                          required=False,
                                                          allow_none=False)
-    status_message = m.fields.String(data_key="StatusMessage", required=False, allow_none=False)
-    warnings = m.fields.Nested(TWarningsSchema, data_key="Warnings", required=False, allow_none=False)
-    job_status = m.fields.String(data_key="JobStatus", required=False, allow_none=False)
-    next_token = m.fields.String(data_key="NextToken", required=False, allow_none=False)
+    status_message = m.fields.String(
+        data_key="StatusMessage", required=False, allow_none=False)
+    warnings = m.fields.Nested(
+        TWarningsSchema, data_key="Warnings", required=False, allow_none=False)
+    job_status = m.fields.String(
+        data_key="JobStatus", required=False, allow_none=False)
+    next_token = m.fields.String(
+        data_key="NextToken", required=False, allow_none=False)
     response_metadata = m.fields.Nested(TResponseMetadataSchema,
                                         data_key="ResponseMetadata",
                                         required=False,


### PR DESCRIPTION
# Context
- Sometimes Textract returns a block with an id in "Relationships" that is not present in the flattened list of blocks
- This is a Textract bug upstream of TRP, but we need a workaround for now
- See "dd615b1f-dad5-487d-8702-8db7c16e8a9a" in "test-jamie-python.pdf" for org "spirals"

# Summary
- New `try_get_block_by_id` method that is localized to `__relationships_recursive` callsite