### PR TITLE
PyPI target fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [tool.poetry]
 name = "streamline-trp"
-version = "0.1.2"
+version = "0.1.4"
 description = ""
 authors = ["Doug Qian <douglas@spirals.so>"]
 readme = "README.md"
-packages = [{include = "src-python"}]
+packages = [{include = "src-python/trp"}]
 
 [tool.poetry.dependencies]
 python = "^3.8"

--- a/src-python/pyproject.toml
+++ b/src-python/pyproject.toml
@@ -1,16 +1,15 @@
 [tool.poetry]
 name = "streamline-trp"
-version = "0.1.4"
+version = "0.1.5"
 description = ""
 authors = ["Doug Qian <douglas@spirals.so>"]
 readme = "README.md"
-packages = [{include = "src-python/trp"}]
+packages = [{include = "trp"}]
 
 [tool.poetry.dependencies]
 python = "^3.8"
 logging = "^0.4.9.6"
 marshmallow = "^3.19.0"
-
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
- [x] Re-ran `poetry install` to confirm new direct `trp` package install instead of `src-python/trp`
- [x] Published version 0.1.5 to PyPI